### PR TITLE
Fix extra closing parenthesis in metrics container

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,8 +771,6 @@
               React.createElement('div', { className: 'metric-value' }, yoyYtdLabel),
               React.createElement('div', { className: 'metric-label' }, 'YoY (YTD)')
             ),
-            
-          ),
           ]
         ),
         // View toggle


### PR DESCRIPTION
## Summary
- remove an extra closing parenthesis from the metrics container element array so the React code parses correctly

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2ab24f94c8322b721f366a6a6a0cd